### PR TITLE
fixed spacing on markdown headers

### DIFF
--- a/newReadMe.md
+++ b/newReadMe.md
@@ -2,7 +2,7 @@
   undefined
   
   ## Description
-  test
+  tst
 
   ## Table of Contents
   - [Description](#description)
@@ -13,20 +13,20 @@
   - [Tests](#tests)
   - [Questions](#questions)
 
-  ##Installation
+  ## Installation
   test
 
-  ##Usage
+  ## Usage
   test
 
-  ##License
+  ## License
   undefined
 
-  ##Contributing
+  ## Contributing
   test
 
-  ##Tests
+  ## Tests
   test
 
-  ##Questions
+  ## Questions
   For additional questions, please reach out on GitHub at https://github.com/test or via email at test. 

--- a/utils/generateMarkdown.js
+++ b/utils/generateMarkdown.js
@@ -32,22 +32,22 @@ function generateMarkdown(data) {
   - [Tests](#tests)
   - [Questions](#questions)
 
-  ##Installation
+  ## Installation
   ${data.installation}
 
-  ##Usage
+  ## Usage
   ${data.usage}
 
-  ##License
+  ## License
   ${renderLicenseSection(data.license)}
 
-  ##Contributing
+  ## Contributing
   ${data.contributing}
 
-  ##Tests
+  ## Tests
   ${data.tests}
 
-  ##Questions
+  ## Questions
   For additional questions, please reach out on GitHub at https://github.com/${data.gitHubUser} or via email at ${data.email}. 
 `;
 }


### PR DESCRIPTION
Added space between `##` and header name of markdown sections in generateMarkdown function so that they will format correctly as separate sections